### PR TITLE
chore(contracts-node): sync polkadot stable2409

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,120 +18,122 @@ members = [
 panic = 'unwind'
 
 [workspace.dependencies]
-clap = { version = "4", features = ["derive"] }
-codec = { package = "parity-scale-codec", version = "3.6.9", default-features = false, features = ["derive"] }
+clap = { version = "4.5.3", features = ["derive"] }
+codec = { package = "parity-scale-codec", version = "3.6.12", default-features = false, features = ["derive"] }
 futures = "0.3.30"
 hex-literal = { version = "0.4.1"}
-jsonrpsee = { version = "0.22", features = ["server"] }
-log = { version = "0.4.20", default-features = false }
-serde = { version = "1.0.195", features = ["derive"] }
-serde_json = "1.0.111"
+jsonrpsee = { version = "0.23.2", features = ["server"] }
+log = { version = "0.4.21", default-features = false }
+serde = { version = "1.0.197", features = ["derive"] }
+serde_json = "1.0.114"
 scale-info = { version = "2.11.1", default-features = false, features = ["derive"] }
 smallvec = "1.11.2"
-color-print = "0.3.5"
+color-print = "0.3.4"
 wasmtime="8.0.1"
 
 # Substrate
-frame-benchmarking = { version = "32.0.0", default-features = false }
-frame-benchmarking-cli = { version = "36.0.0" }
-frame-executive = { version = "32.0.0", default-features = false }
-frame-support = { version = "32.0.0", default-features = false }
-frame-system = { version = "32.0.0", default-features = false }
-frame-system-benchmarking = { version = "32.0.0", default-features = false }
-frame-system-rpc-runtime-api = { version = "30.0.0", default-features = false }
-frame-try-runtime = { version = "0.38.0", default-features = false }
-pallet-aura = { version = "31.0.0", default-features = false }
-pallet-authorship = { version = "32.0.0", default-features = false }
-pallet-balances = { version = "33.0.0", default-features = false }
-pallet-session = { version = "32.0.0", default-features = false }
-pallet-sudo = { version = "32.0.0", default-features = false }
-pallet-timestamp = { version = "31.0.0", default-features = false }
-pallet-transaction-payment = { version = "32.0.0", default-features = false }
-pallet-message-queue = { version = "35.0.0", default-features = false }
-pallet-transaction-payment-rpc = { version = "34.0.0" }
-pallet-transaction-payment-rpc-runtime-api = { version = "32.0.0", default-features = false }
-sc-basic-authorship = { version = "0.38.0" }
-sc-chain-spec = { version = "31.0.0" }
-sc-cli = { version = "0.40.0" }
-sc-client-api = { version = "32.0.0" }
-sc-consensus = { version = "0.37.0" }
-sc-executor = { version = "0.36.0" }
-sc-network = { version = "0.38.0" }
-sc-network-sync = { version = "0.37.0" }
-sc-offchain = { version = "33.0.0" }
-sc-rpc = { version = "33.0.0" }
-sc-service = { version = "0.39.0" }
-sc-sysinfo = { version = "31.0.0" }
-sc-telemetry = { version = "18.0.0" }
-sc-tracing = { version = "32.0.0" }
-sc-transaction-pool = { version = "32.0.0" }
-sc-transaction-pool-api = { version = "32.0.0" }
-sp-api = { version = "30.0.0", default-features = false }
-sp-keyring = { version = "35.0.0", default-features = false }
-sp-block-builder = { version = "30.0.0", default-features = false }
-sp-blockchain = { version = "32.0.0" }
-sp-consensus-aura = { version = "0.36.0", default-features = false }
-sp-core = { version = "32.0.0", default-features = false }
-sp-inherents = { version = "30.0.0", default-features = false }
-sp-io = { version = "34.0.0", default-features = false }
-sp-keystore = { version = "0.38.0" }
-sp-offchain = { version = "30.0.0", default-features = false }
-sp-runtime = { version = "35.0.0", default-features = false }
-sp-session = { version = "31.0.0", default-features = false }
+frame-benchmarking = { version = "37.0.0", default-features = false }
+frame-benchmarking-cli = { version = "42.0.0" }
+frame-executive = { version = "37.0.0", default-features = false }
+frame-support = { version = "37.0.0", default-features = false }
+frame-support-procedural = { version = "30.0.2", default-features = false }
+frame-system = { version = "37.0.0", default-features = false }
+frame-system-benchmarking = { version = "37.0.0", default-features = false }
+frame-system-rpc-runtime-api = { version = "34.0.0", default-features = false }
+frame-try-runtime = { version = "0.43.0", default-features = false }
+pallet-aura = { version = "36.0.0", default-features = false }
+pallet-authorship = { version = "37.0.0", default-features = false }
+pallet-balances = { version = "38.0.0", default-features = false }
+pallet-session = { version = "37.0.0", default-features = false }
+pallet-sudo = { version = "37.0.0", default-features = false }
+pallet-timestamp = { version = "36.0.0", default-features = false }
+pallet-transaction-payment = { version = "37.0.0", default-features = false }
+pallet-message-queue = { version = "40.0.0", default-features = false }
+pallet-transaction-payment-rpc = { version = "40.0.0" }
+pallet-transaction-payment-rpc-runtime-api = { version = "37.0.0", default-features = false }
+sc-basic-authorship = { version = "0.44.0" }
+sc-chain-spec = { version = "37.0.0" }
+sc-cli = { version = "0.46.0" }
+sc-client-api = { version = "37.0.0" }
+sc-consensus = { version = "0.43.0" }
+sc-executor = { version = "0.40.0" }
+sc-network = { version = "0.44.0" }
+sc-network-sync = { version = "0.43.0" }
+sc-offchain = { version = "39.0.0" }
+sc-rpc = { version = "39.0.0" }
+sc-service = { version = "0.45.0" }
+sc-sysinfo = { version = "37.0.0" }
+sc-telemetry = { version = "24.0.0" }
+sc-tracing = { version = "37.0.0" }
+sc-transaction-pool = { version = "37.0.0" }
+sc-transaction-pool-api = { version = "37.0.0" }
+sp-api = { version = "34.0.0", default-features = false }
+sp-keyring = { version = "39.0.0", default-features = false }
+sp-block-builder = { version = "34.0.0", default-features = false }
+sp-blockchain = { version = "37.0.0" }
+sp-consensus-aura = { version = "0.40.0", default-features = false }
+sp-core = { version = "34.0.0", default-features = false }
+sp-inherents = { version = "34.0.0", default-features = false }
+sp-io = { version = "38.0.0", default-features = false }
+sp-keystore = { version = "0.40.0" }
+sp-offchain = { version = "34.0.0", default-features = false }
+sp-runtime = { version = "39.0.0", default-features = false }
+sp-session = { version = "35.0.0", default-features = false }
 sp-std = { version = "14.0.0", default-features = false }
-sp-timestamp = { version = "30.0.0" }
-sp-transaction-pool = { version = "30.0.0", default-features = false }
-sp-version = { version = "33.0.0", default-features = false }
-substrate-frame-rpc-system = { version = "32.0.0" }
-substrate-prometheus-endpoint = { version = "0.17.0" }
-substrate-wasm-builder = { version = "21.0.0" }
+sp-timestamp = { version = "34.0.0" }
+sp-transaction-pool = { version = "34.0.0", default-features = false }
+sp-version = { version = "37.0.0", default-features = false }
+substrate-frame-rpc-system = { version = "38.0.0" }
+prometheus-endpoint = { version = "0.17.0", default-features = false, package = "substrate-prometheus-endpoint" }
+substrate-wasm-builder = { version = "24.0.0" }
 substrate-build-script-utils = { version = "11.0.0" }
 try-runtime-cli = { version = "0.42.0" }
 
 # extra deps for running a solo node on top of a parachain
-pallet-grandpa = { version = "32.0.0", default-features = false }
-sc-consensus-grandpa = { version = "0.23.0", default-features = false }
-sp-consensus-grandpa = { version = "17.0.0", default-features = false }
-sp-genesis-builder = { version = "0.11.0", default-features = false }
+pallet-grandpa = { version = "37.0.0", default-features = false }
+sc-consensus-grandpa = { version = "0.29.0", default-features = false }
+sp-consensus-grandpa = { version = "21.0.0", default-features = false }
+sp-genesis-builder = { version = "0.15.0", default-features = false }
 sp-storage = { version = "21.0.0", default-features = false }
-sc-consensus-aura = { version = "0.38.0", default-features = false }
-sc-consensus-manual-seal = { version = "0.39.0", default-features = false }
+sc-consensus-aura = { version = "0.44.0", default-features = false }
+sc-consensus-manual-seal = { version = "0.45.0", default-features = false }
 
 # extra deps for setting up pallet-contracts
-pallet-contracts = { version = "31.0.0", default-features = false }
-pallet-insecure-randomness-collective-flip = { version = "20.0.0", default-features = false }
-pallet-assets = { version = "33.0.0", default-features = false }
-pallet-utility = { version = "32.0.0", default-features = false }
+pallet-contracts = { version = "37.0.0", default-features = false }
+pallet-insecure-randomness-collective-flip = { version = "25.0.0", default-features = false }
+pallet-assets = { version = "39.0.0", default-features = false }
+pallet-utility = { version = "37.0.0", default-features = false }
 
 # Polkadot
-pallet-xcm = { version = "11.0.0", default-features = false }
-polkadot-cli = { version = "11.0.0", features = ["rococo-native"] }
-polkadot-parachain-primitives = { version = "10.0.0", default-features = false }
-polkadot-primitives = { version = "11.0.0" }
-polkadot-runtime-common = { version = "11.0.0", default-features = false }
-xcm = { version = "11.0.0", package = "staging-xcm", default-features = false }
-xcm-builder = { version = "11.0.0", package = "staging-xcm-builder", default-features = false }
-xcm-executor = { version = "11.0.0", package = "staging-xcm-executor", default-features = false }
+pallet-xcm = { version = "16.0.0", default-features = false }
+polkadot-cli = { features = ["rococo-native"], version = "17.0.0", default-features = false }
+polkadot-parachain-primitives = { version = "14.0.0", default-features = false }
+polkadot-primitives = { version = "15.0.0" }
+polkadot-runtime-common = { version = "16.0.0", default-features = false }
+xcm = { version = "14.1.0", package = "staging-xcm", default-features = false }
+xcm-builder = { version = "16.0.0", package = "staging-xcm-builder", default-features = false }
+xcm-executor = { version = "16.0.0", package = "staging-xcm-executor", default-features = false }
 
 # Cumulus
-cumulus-client-cli = { version = "0.11.0" }
-cumulus-client-collator = { version = "0.11.0" }
-cumulus-client-consensus-proposer = { version = "0.11.0" }
-cumulus-client-consensus-aura = { version = "0.11.0" }
-cumulus-client-consensus-common = { version = "0.11.0" }
-cumulus-client-service = { version = "0.11.0" }
-cumulus-pallet-aura-ext = { version = "0.11.0", default-features = false }
-cumulus-pallet-dmp-queue = { version = "0.11.0", default-features = false }
-cumulus-pallet-parachain-system = { version = "0.11.0", default-features = false, features = ["parameterized-consensus-hook",] }
-cumulus-pallet-session-benchmarking = { version = "13.0.0", default-features = false }
-cumulus-pallet-xcm = { version = "0.11.0", default-features = false }
-cumulus-pallet-xcmp-queue = { version = "0.11.0", default-features = false }
-cumulus-primitives-core = { version = "0.11.0", default-features = false }
-cumulus-primitives-parachain-inherent = { version = "0.11.0" }
-cumulus-primitives-timestamp = { version = "0.11.0", default-features = false }
-cumulus-primitives-utility = { version = "0.11.0", default-features = false }
-cumulus-relay-chain-interface = { version = "0.11.0" }
-pallet-collator-selection = { version = "13.0.0", default-features = false }
-parachain-info = { version = "0.11.0", package = "staging-parachain-info", default-features = false }
-parachains-common = { version = "11.0.0", default-features = false }
+cumulus-client-cli = { version = "0.17.0" }
+cumulus-client-collator = { version = "0.17.0" }
+cumulus-client-consensus-proposer = { version = "0.15.0" }
+cumulus-client-consensus-aura = { version = "0.17.0" }
+cumulus-client-consensus-common = { version = "0.17.0" }
+cumulus-client-service = { version = "0.17.0" }
+cumulus-pallet-aura-ext = { version = "0.16.0", default-features = false }
+cumulus-pallet-dmp-queue = { version = "0.16.0", default-features = false }
+cumulus-pallet-parachain-system = { version = "0.16.0", default-features = false }
+cumulus-pallet-session-benchmarking = { version = "18.0.0", default-features = false }
+cumulus-pallet-xcm = { version = "0.16.0", default-features = false }
+cumulus-pallet-xcmp-queue = { version = "0.16.0", default-features = false }
+cumulus-primitives-aura = { version = "0.15.0", default-features = false }
+cumulus-primitives-core = { version = "0.15.0", default-features = false }
+cumulus-primitives-parachain-inherent = { version = "0.15.0" }
+cumulus-primitives-timestamp = { version = "0.15.0", default-features = false }
+cumulus-primitives-utility = { version = "0.16.0", default-features = false }
+cumulus-relay-chain-interface = { version = "0.17.0" }
+pallet-collator-selection = { version = "18.0.0", default-features = false }
+parachain-info = { version = "0.16.0", package = "staging-parachain-info", default-features = false }
+parachains-common = { version = "17.0.0", default-features = false }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -72,12 +72,10 @@ sp-keyring = { version = "39.0.0", default-features = false }
 sp-block-builder = { version = "34.0.0", default-features = false }
 sp-blockchain = { version = "37.0.1" }
 sp-consensus-aura = { version = "0.40.0", default-features = false }
-sp-consensus-beefy = { version = "22.1.0", default-features = false }
 sp-core = { version = "34.0.0", default-features = false }
 sp-inherents = { version = "34.0.0", default-features = false }
 sp-io = { version = "38.0.0", default-features = false }
 sp-keystore = { version = "0.40.0" }
-sp-mmr-primitives = { version = "34.1.0", default-features = false }
 sp-offchain = { version = "34.0.0", default-features = false }
 sp-runtime = { version = "39.0.1", default-features = false }
 sp-session = { version = "36.0.0", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,122 +18,124 @@ members = [
 panic = 'unwind'
 
 [workspace.dependencies]
-clap = { version = "4.5.3", features = ["derive"] }
+clap = { version = "4.5.10", features = ["derive"] }
 codec = { package = "parity-scale-codec", version = "3.6.12", default-features = false, features = ["derive"] }
 futures = "0.3.30"
 hex-literal = { version = "0.4.1"}
-jsonrpsee = { version = "0.23.2", features = ["server"] }
-log = { version = "0.4.21", default-features = false }
-serde = { version = "1.0.197", features = ["derive"] }
-serde_json = "1.0.114"
+jsonrpsee = { version = "0.24.3", features = ["server"] }
+log = { version = "0.4.22", default-features = false }
+serde = { version = "1.0.209", features = ["derive"] }
+serde_json = "1.0.127"
 scale-info = { version = "2.11.1", default-features = false, features = ["derive"] }
-smallvec = "1.11.2"
+smallvec = "1.11.0"
 color-print = "0.3.4"
 wasmtime="8.0.1"
 
 # Substrate
-frame-benchmarking = { version = "37.0.0", default-features = false }
-frame-benchmarking-cli = { version = "42.0.0" }
-frame-executive = { version = "37.0.0", default-features = false }
-frame-support = { version = "37.0.0", default-features = false }
-frame-support-procedural = { version = "30.0.2", default-features = false }
-frame-system = { version = "37.0.0", default-features = false }
-frame-system-benchmarking = { version = "37.0.0", default-features = false }
+frame-benchmarking = { version = "38.0.0", default-features = false }
+frame-benchmarking-cli = { version = "43.0.0" }
+frame-executive = { version = "38.0.0", default-features = false }
+frame-support = { version = "38.0.0", default-features = false }
+frame-support-procedural = { version = "30.0.3", default-features = false }
+frame-system = { version = "38.0.0", default-features = false }
+frame-system-benchmarking = { version = "38.0.0", default-features = false }
 frame-system-rpc-runtime-api = { version = "34.0.0", default-features = false }
-frame-try-runtime = { version = "0.43.0", default-features = false }
-pallet-aura = { version = "36.0.0", default-features = false }
-pallet-authorship = { version = "37.0.0", default-features = false }
-pallet-balances = { version = "38.0.0", default-features = false }
-pallet-session = { version = "37.0.0", default-features = false }
-pallet-sudo = { version = "37.0.0", default-features = false }
-pallet-timestamp = { version = "36.0.0", default-features = false }
-pallet-transaction-payment = { version = "37.0.0", default-features = false }
-pallet-message-queue = { version = "40.0.0", default-features = false }
-pallet-transaction-payment-rpc = { version = "40.0.0" }
-pallet-transaction-payment-rpc-runtime-api = { version = "37.0.0", default-features = false }
-sc-basic-authorship = { version = "0.44.0" }
-sc-chain-spec = { version = "37.0.0" }
-sc-cli = { version = "0.46.0" }
+frame-try-runtime = { version = "0.44.0", default-features = false }
+pallet-aura = { version = "37.0.0", default-features = false }
+pallet-authorship = { version = "38.0.0", default-features = false }
+pallet-balances = { version = "39.0.0", default-features = false }
+pallet-session = { version = "38.0.0", default-features = false }
+pallet-sudo = { version = "38.0.0", default-features = false }
+pallet-timestamp = { version = "37.0.0", default-features = false }
+pallet-transaction-payment = { version = "38.0.0", default-features = false }
+pallet-message-queue = { version = "41.0.2", default-features = false }
+pallet-transaction-payment-rpc = { version = "41.0.0" }
+pallet-transaction-payment-rpc-runtime-api = { version = "38.0.0", default-features = false }
+sc-basic-authorship = { version = "0.45.0" }
+sc-chain-spec = { version = "38.0.0" }
+sc-cli = { version = "0.47.0" }
 sc-client-api = { version = "37.0.0" }
-sc-consensus = { version = "0.43.0" }
-sc-executor = { version = "0.40.0" }
-sc-network = { version = "0.44.0" }
-sc-network-sync = { version = "0.43.0" }
-sc-offchain = { version = "39.0.0" }
-sc-rpc = { version = "39.0.0" }
-sc-service = { version = "0.45.0" }
-sc-sysinfo = { version = "37.0.0" }
-sc-telemetry = { version = "24.0.0" }
-sc-tracing = { version = "37.0.0" }
+sc-consensus = { version = "0.44.0" }
+sc-executor = { version = "0.40.1" }
+sc-network = { version = "0.45.1" }
+sc-network-sync = { version = "0.44.1" }
+sc-offchain = { version = "40.0.0" }
+sc-rpc = { version = "40.0.0" }
+sc-service = { version = "0.46.0" }
+sc-sysinfo = { version = "38.0.0" }
+sc-telemetry = { version = "25.0.0" }
+sc-tracing = { version = "37.0.1" }
 sc-transaction-pool = { version = "37.0.0" }
 sc-transaction-pool-api = { version = "37.0.0" }
 sp-api = { version = "34.0.0", default-features = false }
 sp-keyring = { version = "39.0.0", default-features = false }
 sp-block-builder = { version = "34.0.0", default-features = false }
-sp-blockchain = { version = "37.0.0" }
+sp-blockchain = { version = "37.0.1" }
 sp-consensus-aura = { version = "0.40.0", default-features = false }
+sp-consensus-beefy = { version = "22.1.0", default-features = false }
 sp-core = { version = "34.0.0", default-features = false }
 sp-inherents = { version = "34.0.0", default-features = false }
 sp-io = { version = "38.0.0", default-features = false }
 sp-keystore = { version = "0.40.0" }
+sp-mmr-primitives = { version = "34.1.0", default-features = false }
 sp-offchain = { version = "34.0.0", default-features = false }
-sp-runtime = { version = "39.0.0", default-features = false }
-sp-session = { version = "35.0.0", default-features = false }
+sp-runtime = { version = "39.0.1", default-features = false }
+sp-session = { version = "36.0.0", default-features = false }
 sp-std = { version = "14.0.0", default-features = false }
 sp-timestamp = { version = "34.0.0" }
 sp-transaction-pool = { version = "34.0.0", default-features = false }
 sp-version = { version = "37.0.0", default-features = false }
-substrate-frame-rpc-system = { version = "38.0.0" }
+substrate-frame-rpc-system = { version = "39.0.0" }
 prometheus-endpoint = { version = "0.17.0", default-features = false, package = "substrate-prometheus-endpoint" }
-substrate-wasm-builder = { version = "24.0.0" }
+substrate-wasm-builder = { version = "24.0.1" }
 substrate-build-script-utils = { version = "11.0.0" }
 try-runtime-cli = { version = "0.42.0" }
 
 # extra deps for running a solo node on top of a parachain
-pallet-grandpa = { version = "37.0.0", default-features = false }
-sc-consensus-grandpa = { version = "0.29.0", default-features = false }
+pallet-grandpa = { version = "38.0.0", default-features = false }
+sc-consensus-grandpa = { version = "0.30.0", default-features = false }
 sp-consensus-grandpa = { version = "21.0.0", default-features = false }
-sp-genesis-builder = { version = "0.15.0", default-features = false }
+sp-genesis-builder = { version = "0.15.1", default-features = false }
 sp-storage = { version = "21.0.0", default-features = false }
-sc-consensus-aura = { version = "0.44.0", default-features = false }
-sc-consensus-manual-seal = { version = "0.45.0", default-features = false }
+sc-consensus-aura = { version = "0.45.0", default-features = false }
+sc-consensus-manual-seal = { version = "0.46.0", default-features = false }
 
 # extra deps for setting up pallet-contracts
-pallet-contracts = { version = "37.0.0", default-features = false }
-pallet-insecure-randomness-collective-flip = { version = "25.0.0", default-features = false }
-pallet-assets = { version = "39.0.0", default-features = false }
-pallet-utility = { version = "37.0.0", default-features = false }
+pallet-contracts = { version = "38.0.0", default-features = false }
+pallet-insecure-randomness-collective-flip = { version = "26.0.0", default-features = false }
+pallet-assets = { version = "40.0.0", default-features = false }
+pallet-utility = { version = "38.0.0", default-features = false }
 
 # Polkadot
-pallet-xcm = { version = "16.0.0", default-features = false }
-polkadot-cli = { features = ["rococo-native"], version = "17.0.0", default-features = false }
+pallet-xcm = { version = "17.0.1", default-features = false }
+polkadot-cli = { version = "19.0.0", default-features = false }
 polkadot-parachain-primitives = { version = "14.0.0", default-features = false }
-polkadot-primitives = { version = "15.0.0" }
-polkadot-runtime-common = { version = "16.0.0", default-features = false }
-xcm = { version = "14.1.0", package = "staging-xcm", default-features = false }
-xcm-builder = { version = "16.0.0", package = "staging-xcm-builder", default-features = false }
-xcm-executor = { version = "16.0.0", package = "staging-xcm-executor", default-features = false }
+polkadot-primitives = { version = "16.0.0" }
+polkadot-runtime-common = { version = "17.0.0", default-features = false }
+xcm = { version = "14.2.0", package = "staging-xcm", default-features = false }
+xcm-builder = { version = "17.0.1", package = "staging-xcm-builder", default-features = false }
+xcm-executor = { version = "17.0.0", package = "staging-xcm-executor", default-features = false }
 
 # Cumulus
-cumulus-client-cli = { version = "0.17.0" }
-cumulus-client-collator = { version = "0.17.0" }
-cumulus-client-consensus-proposer = { version = "0.15.0" }
-cumulus-client-consensus-aura = { version = "0.17.0" }
-cumulus-client-consensus-common = { version = "0.17.0" }
-cumulus-client-service = { version = "0.17.0" }
-cumulus-pallet-aura-ext = { version = "0.16.0", default-features = false }
-cumulus-pallet-dmp-queue = { version = "0.16.0", default-features = false }
-cumulus-pallet-parachain-system = { version = "0.16.0", default-features = false }
-cumulus-pallet-session-benchmarking = { version = "18.0.0", default-features = false }
-cumulus-pallet-xcm = { version = "0.16.0", default-features = false }
-cumulus-pallet-xcmp-queue = { version = "0.16.0", default-features = false }
+cumulus-client-cli = { version = "0.18.0" }
+cumulus-client-collator = { version = "0.18.0" }
+cumulus-client-consensus-proposer = { version = "0.16.0" }
+cumulus-client-consensus-aura = { version = "0.18.0" }
+cumulus-client-consensus-common = { version = "0.18.0" }
+cumulus-client-service = { version = "0.19.0" }
+cumulus-pallet-aura-ext = { version = "0.17.0", default-features = false }
+cumulus-pallet-dmp-queue = { version = "0.17.0", default-features = false }
+cumulus-pallet-parachain-system = { version = "0.17.1", default-features = false }
+cumulus-pallet-session-benchmarking = { version = "19.0.0", default-features = false }
+cumulus-pallet-xcm = { version = "0.17.0", default-features = false }
+cumulus-pallet-xcmp-queue = { version = "0.17.0", default-features = false }
 cumulus-primitives-aura = { version = "0.15.0", default-features = false }
-cumulus-primitives-core = { version = "0.15.0", default-features = false }
-cumulus-primitives-parachain-inherent = { version = "0.15.0" }
-cumulus-primitives-timestamp = { version = "0.15.0", default-features = false }
-cumulus-primitives-utility = { version = "0.16.0", default-features = false }
-cumulus-relay-chain-interface = { version = "0.17.0" }
-pallet-collator-selection = { version = "18.0.0", default-features = false }
-parachain-info = { version = "0.16.0", package = "staging-parachain-info", default-features = false }
-parachains-common = { version = "17.0.0", default-features = false }
+cumulus-primitives-core = { version = "0.16.0", default-features = false }
+cumulus-primitives-parachain-inherent = { version = "0.16.0" }
+cumulus-primitives-timestamp = { version = "0.16.0", default-features = false }
+cumulus-primitives-utility = { version = "0.17.0", default-features = false }
+cumulus-relay-chain-interface = { version = "0.18.0" }
+pallet-collator-selection = { version = "19.0.0", default-features = false }
+parachain-info = { version = "0.17.0", package = "staging-parachain-info", default-features = false }
+parachains-common = { version = "18.0.0", default-features = false }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [workspace.package]
 authors = ["anonymous"]
 edition = "2021"
-version = "0.41.0"
+version = "0.42.0"
 license = "Unlicense"
 homepage = "https://github.com/paritytech/substrate-contracts-node"
 repository = "https://github.com/paritytech/substrate-contracts-node"

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -61,7 +61,7 @@ sp-io = { workspace = true }
 sp-runtime = { workspace = true }
 sp-timestamp = { workspace = true }
 substrate-frame-rpc-system = { workspace = true }
-substrate-prometheus-endpoint = { workspace = true }
+prometheus-endpoint = { workspace = true }
 try-runtime-cli = { workspace = true, optional = true }
 
 # extra for running solo-chain
@@ -71,7 +71,7 @@ sc-consensus-aura = { workspace = true }
 sc-consensus-manual-seal = { workspace = true }
 
 # Polkadot
-polkadot-cli = { workspace = true }
+polkadot-cli = { features = ["rococo-native"], workspace = true }
 polkadot-primitives = { workspace = true }
 xcm = { workspace = true }
 

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -27,8 +27,8 @@ serde_json = { workspace = true }
 wasmtime = { workspace = true }
 
 # Local
-contracts-parachain-runtime = { path = "../parachain-runtime", features = ["parachain"], version = "0.41.0" }
-contracts-node-runtime = { path = "../runtime",  version = "0.41.0" }
+contracts-parachain-runtime = { path = "../parachain-runtime", features = ["parachain"], version = "0.42.0" }
+contracts-node-runtime = { path = "../runtime",  version = "0.42.0" }
 
 # Substrate
 frame-benchmarking = { workspace = true }

--- a/node/src/chain_spec.rs
+++ b/node/src/chain_spec.rs
@@ -9,7 +9,7 @@ use sp_core::{sr25519, Pair, Public};
 use sp_runtime::traits::{IdentifyAccount, Verify};
 
 /// Specialized `ChainSpec` for the normal parachain runtime.
-pub type ChainSpec = sc_service::GenericChainSpec<(), Extensions>;
+pub type ChainSpec = sc_service::GenericChainSpec<Extensions>;
 
 /// The default XCM version to set in genesis config.
 const SAFE_XCM_VERSION: u32 = xcm::prelude::XCM_VERSION;
@@ -26,8 +26,10 @@ pub fn get_from_seed<TPublic: Public>(seed: &str) -> <TPublic::Pair as Pair>::Pu
 #[serde(deny_unknown_fields)]
 pub struct Extensions {
 	/// The relay chain of the Parachain.
+	#[serde(alias = "relayChain", alias = "RelayChain")]
 	pub relay_chain: String,
 	/// The id of the Parachain.
+	#[serde(alias = "paraId", alias = "ParaId")]
 	pub para_id: u32,
 }
 

--- a/node/src/chain_spec/dev.rs
+++ b/node/src/chain_spec/dev.rs
@@ -1,10 +1,10 @@
-use contracts_node_runtime::{AccountId, RuntimeGenesisConfig, Signature, WASM_BINARY};
+use contracts_node_runtime::{AccountId, Signature, WASM_BINARY};
 use sc_service::ChainType;
 use sp_core::{sr25519, Pair, Public};
 use sp_runtime::traits::{IdentifyAccount, Verify};
 
 /// Specialized `ChainSpec`. This is a specialization of the general Substrate ChainSpec type.
-pub type ChainSpec = sc_service::GenericChainSpec<RuntimeGenesisConfig>;
+pub type ChainSpec = sc_service::GenericChainSpec;
 
 /// Generate a crypto pair from seed.
 pub fn get_from_seed<TPublic: Public>(seed: &str) -> <TPublic::Pair as Pair>::Public {
@@ -24,35 +24,31 @@ where
 }
 
 pub fn development_config() -> Result<ChainSpec, String> {
-	Ok(ChainSpec::builder(
-		WASM_BINARY.ok_or_else(|| "Development wasm not available".to_string())?,
-		None,
-	)
-	.with_name("Development")
-	.with_id("dev")
-	.with_protocol_id("dev")
-	.with_chain_type(ChainType::Development)
-	.with_genesis_config_patch(testnet_genesis(
-		// Sudo account
-		get_account_id_from_seed::<sr25519::Public>("Alice"),
-		// Pre-funded accounts
-		vec![
+	Ok(ChainSpec::builder(WASM_BINARY.expect("Development wasm not available"), Default::default())
+		.with_name("Development")
+		.with_id("dev")
+		.with_chain_type(ChainType::Development)
+		.with_genesis_config_patch(testnet_genesis(
+			// Sudo account
 			get_account_id_from_seed::<sr25519::Public>("Alice"),
-			get_account_id_from_seed::<sr25519::Public>("Alice//stash"),
-			get_account_id_from_seed::<sr25519::Public>("Bob"),
-			get_account_id_from_seed::<sr25519::Public>("Bob//stash"),
-			get_account_id_from_seed::<sr25519::Public>("Charlie"),
-			get_account_id_from_seed::<sr25519::Public>("Charlie//stash"),
-			get_account_id_from_seed::<sr25519::Public>("Dave"),
-			get_account_id_from_seed::<sr25519::Public>("Dave//stash"),
-			get_account_id_from_seed::<sr25519::Public>("Eve"),
-			get_account_id_from_seed::<sr25519::Public>("Eve//stash"),
-			get_account_id_from_seed::<sr25519::Public>("Ferdie"),
-			get_account_id_from_seed::<sr25519::Public>("Ferdie//stash"),
-		],
-		true,
-	))
-	.build())
+			// Pre-funded accounts
+			vec![
+				get_account_id_from_seed::<sr25519::Public>("Alice"),
+				get_account_id_from_seed::<sr25519::Public>("Alice//stash"),
+				get_account_id_from_seed::<sr25519::Public>("Bob"),
+				get_account_id_from_seed::<sr25519::Public>("Bob//stash"),
+				get_account_id_from_seed::<sr25519::Public>("Charlie"),
+				get_account_id_from_seed::<sr25519::Public>("Charlie//stash"),
+				get_account_id_from_seed::<sr25519::Public>("Dave"),
+				get_account_id_from_seed::<sr25519::Public>("Dave//stash"),
+				get_account_id_from_seed::<sr25519::Public>("Eve"),
+				get_account_id_from_seed::<sr25519::Public>("Eve//stash"),
+				get_account_id_from_seed::<sr25519::Public>("Ferdie"),
+				get_account_id_from_seed::<sr25519::Public>("Ferdie//stash"),
+			],
+			true,
+		))
+		.build())
 }
 
 /// Configure initial storage state for FRAME modules.

--- a/node/src/cli.rs
+++ b/node/src/cli.rs
@@ -35,11 +35,6 @@ pub enum Subcommand {
 	/// The pallet benchmarking moved to the `pallet` sub-command.
 	#[command(subcommand)]
 	Benchmark(frame_benchmarking_cli::BenchmarkCmd),
-
-	/// Try-runtime has migrated to a standalone
-	/// [CLI](<https://github.com/paritytech/try-runtime-cli>). The subcommand exists as a stub and
-	/// deprecation notice. It will be removed entirely some time after Janurary 2024.
-	TryRuntime,
 }
 
 const AFTER_HELP_EXAMPLE: &str = color_print::cstr!(

--- a/node/src/command.rs
+++ b/node/src/command.rs
@@ -1,12 +1,10 @@
-use std::net::SocketAddr;
-
 use contracts_parachain_runtime::Block;
 use cumulus_primitives_core::ParaId;
 use frame_benchmarking_cli::{BenchmarkCmd, SUBSTRATE_REFERENCE_HARDWARE};
 use log::info;
 use sc_cli::{
 	ChainSpec, CliConfiguration, DefaultConfigurationValues, ImportParams, KeystoreParams,
-	NetworkParams, Result, SharedParams, SubstrateCli,
+	NetworkParams, Result, RpcEndpoint, SharedParams, SubstrateCli,
 };
 use sc_service::config::{BasePath, PrometheusConfig};
 use sp_runtime::traits::AccountIdConversion;
@@ -19,7 +17,7 @@ use crate::{
 
 fn load_spec(id: &str) -> std::result::Result<Box<dyn ChainSpec>, String> {
 	Ok(match id {
-		"" | "dev" => Box::new(chain_spec::dev::development_config().unwrap()),
+		"" | "dev" => Box::new(chain_spec::dev::development_config()?),
 		"contracts-parachain-local" => Box::new(chain_spec::local_testnet_config()),
 		path => Box::new(chain_spec::ChainSpec::from_json_file(std::path::PathBuf::from(path))?),
 	})
@@ -226,14 +224,20 @@ pub fn run() -> Result<()> {
 
 			runner.run_node_until_exit(|config| async move {
 				if config.chain_spec.name() == "Development" {
-					return dev::new_full(config, cli.finalize_delay_sec.into())
-						.map_err(sc_cli::Error::Service);
+					return dev::new_full::<sc_network::NetworkWorker<_, _>>(
+						config,
+						cli.finalize_delay_sec.into(),
+					)
+					.map_err(sc_cli::Error::Service);
 				}
 
 				let hwbench = (!cli.no_hardware_benchmarks)
 					.then_some(config.database.path().map(|database_path| {
 						let _ = std::fs::create_dir_all(database_path);
-						sc_sysinfo::gather_hwbench(Some(database_path))
+						sc_sysinfo::gather_hwbench(
+							Some(database_path),
+							&SUBSTRATE_REFERENCE_HARDWARE,
+						)
 					}))
 					.flatten();
 
@@ -308,7 +312,7 @@ impl CliConfiguration<Self> for RelayChainCli {
 			.or_else(|| self.base_path.clone().map(Into::into)))
 	}
 
-	fn rpc_addr(&self, default_listen_port: u16) -> Result<Option<SocketAddr>> {
+	fn rpc_addr(&self, default_listen_port: u16) -> Result<Option<Vec<RpcEndpoint>>> {
 		self.base.base.rpc_addr(default_listen_port)
 	}
 
@@ -320,15 +324,9 @@ impl CliConfiguration<Self> for RelayChainCli {
 		self.base.base.prometheus_config(default_listen_port, chain_spec)
 	}
 
-	fn init<F>(
-		&self,
-		_support_url: &String,
-		_impl_version: &String,
-		_logger_hook: F,
-		_config: &sc_service::Configuration,
-	) -> Result<()>
+	fn init<F>(&self, _support_url: &String, _impl_version: &String, _logger_hook: F) -> Result<()>
 	where
-		F: FnOnce(&mut sc_cli::LoggerBuilder, &sc_service::Configuration),
+		F: FnOnce(&mut sc_cli::LoggerBuilder),
 	{
 		unreachable!("PolkadotCli is never initialized; qed");
 	}

--- a/node/src/command.rs
+++ b/node/src/command.rs
@@ -185,7 +185,11 @@ pub fn run() -> Result<()> {
 			match cmd {
 				BenchmarkCmd::Pallet(cmd) =>
 					if cfg!(feature = "runtime-benchmarks") {
-						runner.sync_run(|config| cmd.run::<sp_runtime::traits::HashingFor<Block>, ()>(config))
+						runner.sync_run(|config| {
+							cmd.run_with_spec::<sp_runtime::traits::HashingFor<Block>, ()>(Some(
+								config.chain_spec,
+							))
+						})
 					} else {
 						Err("Benchmarking wasn't enabled when building the node. \
 					You can enable it with `--features runtime-benchmarks`."
@@ -196,13 +200,11 @@ pub fn run() -> Result<()> {
 					cmd.run(partials.client)
 				}),
 				#[cfg(not(feature = "runtime-benchmarks"))]
-				BenchmarkCmd::Storage(_) =>
-					return Err(sc_cli::Error::Input(
-						"Compile with --features=runtime-benchmarks \
+				BenchmarkCmd::Storage(_) => Err(sc_cli::Error::Input(
+					"Compile with --features=runtime-benchmarks \
 						to enable storage benchmarks."
-							.into(),
-					)
-					.into()),
+						.into(),
+				)),
 				#[cfg(feature = "runtime-benchmarks")]
 				BenchmarkCmd::Storage(cmd) => runner.sync_run(|config| {
 					let partials = new_partial(&config)?;
@@ -218,14 +220,14 @@ pub fn run() -> Result<()> {
 				_ => Err("Benchmarking sub-command unsupported".into()),
 			}
 		},
-		Some(Subcommand::TryRuntime) => Err("The `try-runtime` subcommand has been migrated to a standalone CLI (https://github.com/paritytech/try-runtime-cli). It is no longer being maintained here and will be removed entirely some time after January 2024. Please remove this subcommand from your runtime and use the standalone CLI.".into()),
 		None => {
 			let runner = cli.create_runner(&cli.run.normalize())?;
 			let collator_options = cli.run.collator_options();
 
 			runner.run_node_until_exit(|config| async move {
 				if config.chain_spec.name() == "Development" {
-					return dev::new_full(config, cli.finalize_delay_sec.into()).map_err(sc_cli::Error::Service);
+					return dev::new_full(config, cli.finalize_delay_sec.into())
+						.map_err(sc_cli::Error::Service);
 				}
 
 				let hwbench = (!cli.no_hardware_benchmarks)
@@ -246,17 +248,11 @@ pub fn run() -> Result<()> {
 
 				let id = ParaId::from(para_id);
 
-				let parachain_account =
-					AccountIdConversion::<polkadot_primitives::AccountId>::into_account_truncating(
-						&id,
-					);
-
 				let tokio_handle = config.tokio_handle.clone();
 				let polkadot_config =
 					SubstrateCli::create_configuration(&polkadot_cli, &polkadot_cli, tokio_handle)
 						.map_err(|err| format!("Relay chain argument error: {}", err))?;
 
-				info!("Parachain Account: {parachain_account}");
 				info!("Is collating: {}", if config.role.is_authority() { "yes" } else { "no" });
 
 				crate::service::start_parachain_node(

--- a/node/src/command.rs
+++ b/node/src/command.rs
@@ -7,7 +7,6 @@ use sc_cli::{
 	NetworkParams, Result, RpcEndpoint, SharedParams, SubstrateCli,
 };
 use sc_service::config::{BasePath, PrometheusConfig};
-use sp_runtime::traits::AccountIdConversion;
 
 use crate::{
 	chain_spec,

--- a/node/src/rpc.rs
+++ b/node/src/rpc.rs
@@ -9,7 +9,6 @@ use std::sync::Arc;
 
 use contracts_parachain_runtime::{opaque::Block, AccountId, Balance, Nonce};
 
-pub use sc_rpc::DenyUnsafe;
 use sc_transaction_pool_api::TransactionPool;
 use sp_api::ProvideRuntimeApi;
 use sp_block_builder::BlockBuilder;
@@ -24,8 +23,6 @@ pub struct FullDeps<C, P> {
 	pub client: Arc<C>,
 	/// Transaction pool instance.
 	pub pool: Arc<P>,
-	/// Whether to deny unsafe calls
-	pub deny_unsafe: DenyUnsafe,
 }
 
 /// Instantiate all RPC extensions.
@@ -48,9 +45,9 @@ where
 	use substrate_frame_rpc_system::{System, SystemApiServer};
 
 	let mut module = RpcExtension::new(());
-	let FullDeps { client, pool, deny_unsafe } = deps;
+	let FullDeps { client, pool } = deps;
 
-	module.merge(System::new(client.clone(), pool, deny_unsafe).into_rpc())?;
+	module.merge(System::new(client.clone(), pool).into_rpc())?;
 	module.merge(TransactionPayment::new(client).into_rpc())?;
 	Ok(module)
 }

--- a/node/src/service.rs
+++ b/node/src/service.rs
@@ -74,15 +74,16 @@ pub fn new_partial(config: &Configuration) -> Result<Service, sc_service::Error>
 		.transpose()?;
 
 	let heap_pages = config
+		.executor
 		.default_heap_pages
 		.map_or(DEFAULT_HEAP_ALLOC_STRATEGY, |h| HeapAllocStrategy::Static { extra_pages: h as _ });
 
 	let executor = ParachainExecutor::builder()
-		.with_execution_method(config.wasm_method)
+		.with_execution_method(config.executor.wasm_method)
 		.with_onchain_heap_alloc_strategy(heap_pages)
 		.with_offchain_heap_alloc_strategy(heap_pages)
-		.with_max_runtime_instances(config.max_runtime_instances)
-		.with_runtime_cache_size(config.runtime_cache_size)
+		.with_max_runtime_instances(config.executor.max_runtime_instances)
+		.with_runtime_cache_size(config.executor.runtime_cache_size)
 		.build();
 
 	let (client, backend, keystore_container, task_manager) =
@@ -233,11 +234,12 @@ pub async fn start_parachain_node(
 
 	let params = new_partial(&parachain_config)?;
 	let (block_import, mut telemetry, telemetry_worker_handle) = params.other;
+	let prometheus_registry = parachain_config.prometheus_registry().cloned();
 	let net_config = sc_network::config::FullNetworkConfiguration::<
 		_,
 		_,
 		sc_network::NetworkWorker<Block, Hash>,
-	>::new(&parachain_config.network);
+	>::new(&parachain_config.network, prometheus_registry.clone());
 
 	let client = params.client.clone();
 	let backend = params.backend.clone();
@@ -255,7 +257,6 @@ pub async fn start_parachain_node(
 	.map_err(|e| sc_service::Error::Application(Box::new(e) as Box<_>))?;
 
 	let validator = parachain_config.role.is_authority();
-	let prometheus_registry = parachain_config.prometheus_registry().cloned();
 	let transaction_pool = params.transaction_pool.clone();
 	let import_queue_service = params.import_queue.service();
 
@@ -302,12 +303,9 @@ pub async fn start_parachain_node(
 		let client = client.clone();
 		let transaction_pool = transaction_pool.clone();
 
-		Box::new(move |deny_unsafe, _| {
-			let deps = crate::rpc::FullDeps {
-				client: client.clone(),
-				pool: transaction_pool.clone(),
-				deny_unsafe,
-			};
+		Box::new(move |_| {
+			let deps =
+				crate::rpc::FullDeps { client: client.clone(), pool: transaction_pool.clone() };
 
 			crate::rpc::create_full(deps).map_err(Into::into)
 		})
@@ -333,7 +331,7 @@ pub async fn start_parachain_node(
 		// Here you can check whether the hardware meets your chains' requirements. Putting a link
 		// in there and swapping out the requirements for your own are probably a good idea. The
 		// requirements for a para-chain are dictated by its relay-chain.
-		match SUBSTRATE_REFERENCE_HARDWARE.check_hardware(&hwbench) {
+		match SUBSTRATE_REFERENCE_HARDWARE.check_hardware(&hwbench, false) {
 			Err(err) if validator => {
 				log::warn!(
 				"⚠️  The hardware does not meet the minimal requirements {} for role 'Authority'.",

--- a/node/src/service.rs
+++ b/node/src/service.rs
@@ -11,9 +11,9 @@ use contracts_parachain_runtime::{
 	opaque::{Block, Hash},
 	RuntimeApi,
 };
-
 // Cumulus Imports
 use cumulus_client_collator::service::CollatorService;
+use cumulus_client_consensus_aura::collators::lookahead::{self as aura, Params as AuraParams};
 use cumulus_client_consensus_common::ParachainBlockImport as TParachainBlockImport;
 use cumulus_client_consensus_proposer::Proposer;
 use cumulus_client_service::{
@@ -21,7 +21,10 @@ use cumulus_client_service::{
 	BuildNetworkParams, CollatorSybilResistance, DARecoveryProfile, ParachainHostFunctions,
 	StartRelayChainTasksParams,
 };
-use cumulus_primitives_core::{relay_chain::CollatorPair, ParaId};
+use cumulus_primitives_core::{
+	relay_chain::{CollatorPair, ValidationCode},
+	ParaId,
+};
 use cumulus_relay_chain_interface::{OverseerHandle, RelayChainInterface};
 
 // Substrate Imports
@@ -31,7 +34,6 @@ use sc_client_api::Backend;
 use sc_consensus::ImportQueue;
 use sc_executor::{HeapAllocStrategy, WasmExecutor, DEFAULT_HEAP_ALLOC_STRATEGY};
 use sc_network::NetworkBlock;
-use sc_network_sync::SyncingService;
 use sc_service::{Configuration, PartialComponents, TFullBackend, TFullClient, TaskManager};
 use sc_telemetry::{Telemetry, TelemetryHandle, TelemetryWorker, TelemetryWorkerHandle};
 use sc_transaction_pool_api::OffchainTransactionPoolFactory;
@@ -84,10 +86,11 @@ pub fn new_partial(config: &Configuration) -> Result<Service, sc_service::Error>
 		.build();
 
 	let (client, backend, keystore_container, task_manager) =
-		sc_service::new_full_parts::<Block, RuntimeApi, _>(
+		sc_service::new_full_parts_record_import::<Block, RuntimeApi, _>(
 			config,
 			telemetry.as_ref().map(|(_, telemetry)| telemetry.handle()),
 			executor,
+			true,
 		)?;
 	let client = Arc::new(client);
 
@@ -114,7 +117,7 @@ pub fn new_partial(config: &Configuration) -> Result<Service, sc_service::Error>
 		config,
 		telemetry.as_ref().map(|telemetry| telemetry.handle()),
 		&task_manager,
-	)?;
+	);
 
 	Ok(PartialComponents {
 		backend,
@@ -128,11 +131,98 @@ pub fn new_partial(config: &Configuration) -> Result<Service, sc_service::Error>
 	})
 }
 
+/// Build the import queue for the parachain runtime.
+fn build_import_queue(
+	client: Arc<ParachainClient>,
+	block_import: ParachainBlockImport,
+	config: &Configuration,
+	telemetry: Option<TelemetryHandle>,
+	task_manager: &TaskManager,
+) -> sc_consensus::DefaultImportQueue<Block> {
+	cumulus_client_consensus_aura::equivocation_import_queue::fully_verifying_import_queue::<
+		sp_consensus_aura::sr25519::AuthorityPair,
+		_,
+		_,
+		_,
+		_,
+	>(
+		client,
+		block_import,
+		move |_, _| async move {
+			let timestamp = sp_timestamp::InherentDataProvider::from_system_time();
+			Ok(timestamp)
+		},
+		&task_manager.spawn_essential_handle(),
+		config.prometheus_registry(),
+		telemetry,
+	)
+}
+
+#[allow(clippy::too_many_arguments)]
+fn start_consensus(
+	client: Arc<ParachainClient>,
+	backend: Arc<ParachainBackend>,
+	block_import: ParachainBlockImport,
+	prometheus_registry: Option<&Registry>,
+	telemetry: Option<TelemetryHandle>,
+	task_manager: &TaskManager,
+	relay_chain_interface: Arc<dyn RelayChainInterface>,
+	transaction_pool: Arc<sc_transaction_pool::FullPool<Block, ParachainClient>>,
+	keystore: KeystorePtr,
+	relay_chain_slot_duration: Duration,
+	para_id: ParaId,
+	collator_key: CollatorPair,
+	overseer_handle: OverseerHandle,
+	announce_block: Arc<dyn Fn(Hash, Option<Vec<u8>>) + Send + Sync>,
+) -> Result<(), sc_service::Error> {
+	let proposer_factory = sc_basic_authorship::ProposerFactory::with_proof_recording(
+		task_manager.spawn_handle(),
+		client.clone(),
+		transaction_pool,
+		prometheus_registry,
+		telemetry.clone(),
+	);
+
+	let proposer = Proposer::new(proposer_factory);
+
+	let collator_service = CollatorService::new(
+		client.clone(),
+		Arc::new(task_manager.spawn_handle()),
+		announce_block,
+		client.clone(),
+	);
+
+	let params = AuraParams {
+		create_inherent_data_providers: move |_, ()| async move { Ok(()) },
+		block_import,
+		para_client: client.clone(),
+		para_backend: backend,
+		relay_client: relay_chain_interface,
+		code_hash_provider: move |block_hash| {
+			client.code_at(block_hash).ok().map(|c| ValidationCode::from(c).hash())
+		},
+		keystore,
+		collator_key,
+		para_id,
+		overseer_handle,
+		relay_chain_slot_duration,
+		proposer,
+		collator_service,
+		authoring_duration: Duration::from_millis(2000),
+		reinitialize: false,
+	};
+
+	let fut = aura::run::<Block, sp_consensus_aura::sr25519::AuthorityPair, _, _, _, _, _, _, _, _>(
+		params,
+	);
+	task_manager.spawn_essential_handle().spawn("aura", None, fut);
+
+	Ok(())
+}
+
 /// Start a node with the given parachain `Configuration` and relay chain `Configuration`.
-///
-/// This is the actual implementation that is abstract over the executor and the runtime api.
 #[sc_tracing::logging::prefix_logs_with("Parachain")]
-async fn start_node_impl(
+pub async fn start_parachain_node(
 	parachain_config: Configuration,
 	polkadot_config: Configuration,
 	collator_options: CollatorOptions,
@@ -143,7 +233,11 @@ async fn start_node_impl(
 
 	let params = new_partial(&parachain_config)?;
 	let (block_import, mut telemetry, telemetry_worker_handle) = params.other;
-	let net_config = sc_network::config::FullNetworkConfiguration::new(&parachain_config.network);
+	let net_config = sc_network::config::FullNetworkConfiguration::<
+		_,
+		_,
+		sc_network::NetworkWorker<Block, Hash>,
+	>::new(&parachain_config.network);
 
 	let client = params.client.clone();
 	let backend = params.backend.clone();
@@ -165,6 +259,8 @@ async fn start_node_impl(
 	let transaction_pool = params.transaction_pool.clone();
 	let import_queue_service = params.import_queue.service();
 
+	// NOTE: because we use Aura here explicitly, we can use `CollatorSybilResistance::Resistant`
+	// when starting the network.
 	let (network, system_rpc_tx, tx_handler_controller, start_network, sync_service) =
 		build_network(BuildNetworkParams {
 			parachain_config: &parachain_config,
@@ -192,7 +288,7 @@ async fn start_node_impl(
 				transaction_pool: Some(OffchainTransactionPoolFactory::new(
 					transaction_pool.clone(),
 				)),
-				network_provider: network.clone(),
+				network_provider: Arc::new(network.clone()),
 				is_validator: parachain_config.role.is_authority(),
 				enable_http_requests: false,
 				custom_extensions: move |_| vec![],
@@ -224,8 +320,8 @@ async fn start_node_impl(
 		task_manager: &mut task_manager,
 		config: parachain_config,
 		keystore: params.keystore_container.keystore(),
-		backend,
-		network: network.clone(),
+		backend: backend.clone(),
+		network,
 		sync_service: sync_service.clone(),
 		system_rpc_tx,
 		tx_handler_controller,
@@ -288,13 +384,13 @@ async fn start_node_impl(
 	if validator {
 		start_consensus(
 			client.clone(),
+			backend,
 			block_import,
 			prometheus_registry.as_ref(),
 			telemetry.as_ref().map(|t| t.handle()),
 			&task_manager,
-			relay_chain_interface.clone(),
+			relay_chain_interface,
 			transaction_pool,
-			sync_service.clone(),
 			params.keystore_container.keystore(),
 			relay_chain_slot_duration,
 			para_id,
@@ -307,106 +403,4 @@ async fn start_node_impl(
 	start_network.start_network();
 
 	Ok((task_manager, client))
-}
-
-/// Build the import queue for the parachain runtime.
-fn build_import_queue(
-	client: Arc<ParachainClient>,
-	block_import: ParachainBlockImport,
-	config: &Configuration,
-	telemetry: Option<TelemetryHandle>,
-	task_manager: &TaskManager,
-) -> Result<sc_consensus::DefaultImportQueue<Block>, sc_service::Error> {
-	let slot_duration = cumulus_client_consensus_aura::slot_duration(&*client)?;
-
-	Ok(cumulus_client_consensus_aura::equivocation_import_queue::fully_verifying_import_queue::<
-		sp_consensus_aura::sr25519::AuthorityPair,
-		_,
-		_,
-		_,
-		_,
-	>(
-		client,
-		block_import,
-		move |_, _| async move {
-			let timestamp = sp_timestamp::InherentDataProvider::from_system_time();
-			Ok(timestamp)
-		},
-		&task_manager.spawn_essential_handle(),
-		config.prometheus_registry(),
-		telemetry,
-	))
-}
-
-fn start_consensus(
-	client: Arc<ParachainClient>,
-	block_import: ParachainBlockImport,
-	prometheus_registry: Option<&Registry>,
-	telemetry: Option<TelemetryHandle>,
-	task_manager: &TaskManager,
-	relay_chain_interface: Arc<dyn RelayChainInterface>,
-	transaction_pool: Arc<sc_transaction_pool::FullPool<Block, ParachainClient>>,
-	sync_oracle: Arc<SyncingService<Block>>,
-	keystore: KeystorePtr,
-	relay_chain_slot_duration: Duration,
-	para_id: ParaId,
-	collator_key: CollatorPair,
-	overseer_handle: OverseerHandle,
-	announce_block: Arc<dyn Fn(Hash, Option<Vec<u8>>) + Send + Sync>,
-) -> Result<(), sc_service::Error> {
-	use cumulus_client_consensus_aura::collators::basic::{
-		self as basic_aura, Params as BasicAuraParams,
-	};
-
-	let proposer_factory = sc_basic_authorship::ProposerFactory::with_proof_recording(
-		task_manager.spawn_handle(),
-		client.clone(),
-		transaction_pool,
-		prometheus_registry,
-		telemetry.clone(),
-	);
-
-	let proposer = Proposer::new(proposer_factory);
-
-	let collator_service = CollatorService::new(
-		client.clone(),
-		Arc::new(task_manager.spawn_handle()),
-		announce_block,
-		client.clone(),
-	);
-
-	let params = BasicAuraParams {
-		create_inherent_data_providers: move |_, ()| async move { Ok(()) },
-		block_import,
-		para_client: client,
-		relay_client: relay_chain_interface,
-		keystore,
-		collator_key,
-		para_id,
-		overseer_handle,
-		relay_chain_slot_duration,
-		proposer,
-		collator_service,
-		// Very limited proposal time.
-		authoring_duration: Duration::from_millis(500),
-		collation_request_receiver: None,
-	};
-
-	let fut = basic_aura::run::<Block, sp_consensus_aura::sr25519::AuthorityPair, _, _, _, _, _, _>(
-		params,
-	);
-	task_manager.spawn_essential_handle().spawn("aura", None, fut);
-
-	Ok(())
-}
-
-/// Start a parachain node.
-pub async fn start_parachain_node(
-	parachain_config: Configuration,
-	polkadot_config: Configuration,
-	collator_options: CollatorOptions,
-	para_id: ParaId,
-	hwbench: Option<sc_sysinfo::HwBench>,
-) -> sc_service::error::Result<(TaskManager, Arc<ParachainClient>)> {
-	start_node_impl(parachain_config, polkadot_config, collator_options, para_id, hwbench).await
 }

--- a/parachain-runtime/Cargo.toml
+++ b/parachain-runtime/Cargo.toml
@@ -42,8 +42,10 @@ pallet-transaction-payment-rpc-runtime-api = { workspace = true }
 sp-api = { workspace = true }
 sp-block-builder = { workspace = true }
 sp-consensus-aura = { workspace = true }
+sp-consensus-beefy = { workspace = true }
 sp-core = { workspace = true }
 sp-inherents = { workspace = true }
+sp-mmr-primitives = { workspace = true }
 sp-offchain = { workspace = true }
 sp-runtime = { workspace = true }
 sp-session = { workspace = true }
@@ -123,8 +125,10 @@ std = [
 	"sp-api/std",
 	"sp-block-builder/std",
 	"sp-consensus-aura/std",
+	"sp-consensus-beefy/std",
 	"sp-core/std",
 	"sp-inherents/std",
+	"sp-mmr-primitives/std",
 	"sp-offchain/std",
 	"sp-runtime/std",
 	"sp-session/std",

--- a/parachain-runtime/Cargo.toml
+++ b/parachain-runtime/Cargo.toml
@@ -14,10 +14,12 @@ targets = ["x86_64-unknown-linux-gnu"]
 substrate-wasm-builder = {workspace = true, optional = true }
 
 [dependencies]
-codec = { package = "parity-scale-codec", version = "3.6.9", default-features = false, features = ["derive"] }
+codec = { features = [
+	"derive",
+], workspace = true }
 hex-literal = { version = "0.4.1", optional = true }
-log = { version = "0.4.20", default-features = false }
-scale-info = { version = "2.11.1", default-features = false, features = ["derive"] }
+log = { version = "0.4.21", default-features = false }
+scale-info = { workspace = true }
 smallvec = "1.11.2"
 
 # Substrate
@@ -65,6 +67,7 @@ cumulus-pallet-parachain-system = { workspace = true }
 cumulus-pallet-session-benchmarking = { workspace = true }
 cumulus-pallet-xcm = { workspace = true }
 cumulus-pallet-xcmp-queue = { workspace = true }
+cumulus-primitives-aura = { workspace = true }
 cumulus-primitives-core = { workspace = true }
 cumulus-primitives-timestamp = { workspace = true }
 cumulus-primitives-utility = { workspace = true }
@@ -89,6 +92,7 @@ std = [
 	"cumulus-pallet-parachain-system/std",
 	"cumulus-pallet-xcm/std",
 	"cumulus-pallet-xcmp-queue/std",
+	"cumulus-primitives-aura/std",
 	"cumulus-primitives-core/std",
 	"cumulus-primitives-timestamp/std",
 	"cumulus-primitives-utility/std",

--- a/parachain-runtime/Cargo.toml
+++ b/parachain-runtime/Cargo.toml
@@ -42,10 +42,8 @@ pallet-transaction-payment-rpc-runtime-api = { workspace = true }
 sp-api = { workspace = true }
 sp-block-builder = { workspace = true }
 sp-consensus-aura = { workspace = true }
-sp-consensus-beefy = { workspace = true }
 sp-core = { workspace = true }
 sp-inherents = { workspace = true }
-sp-mmr-primitives = { workspace = true }
 sp-offchain = { workspace = true }
 sp-runtime = { workspace = true }
 sp-session = { workspace = true }
@@ -125,10 +123,8 @@ std = [
 	"sp-api/std",
 	"sp-block-builder/std",
 	"sp-consensus-aura/std",
-	"sp-consensus-beefy/std",
 	"sp-core/std",
 	"sp-inherents/std",
-	"sp-mmr-primitives/std",
 	"sp-offchain/std",
 	"sp-runtime/std",
 	"sp-session/std",

--- a/parachain-runtime/src/lib.rs
+++ b/parachain-runtime/src/lib.rs
@@ -47,6 +47,8 @@ use frame_system::{
 use pallet_xcm::{EnsureXcm, IsVoiceOfBody};
 use parachains_common::message_queue::{NarrowOriginToSibling, ParaIdToSibling};
 pub use sp_consensus_aura::sr25519::AuthorityId as AuraId;
+use sp_consensus_beefy::ecdsa_crypto::{AuthorityId as BeefyId, Signature as BeefySignature};
+use sp_mmr_primitives as mmr;
 pub use sp_runtime::{MultiAddress, Perbill, Permill};
 #[cfg(feature = "std")]
 use sp_version::NativeVersion;
@@ -897,6 +899,93 @@ impl_runtime_apis! {
 
 		fn preset_names() -> Vec<sp_genesis_builder::PresetId> {
 			Default::default()
+		}
+	}
+
+	impl sp_consensus_beefy::BeefyApi<Block, BeefyId> for Runtime {
+		fn beefy_genesis() -> Option<BlockNumber> {
+			// dummy implementation due to lack of BEEFY pallet.
+			None
+		}
+
+		fn validator_set() -> Option<sp_consensus_beefy::ValidatorSet<BeefyId>> {
+			// dummy implementation due to lack of BEEFY pallet.
+			None
+		}
+
+		fn submit_report_double_voting_unsigned_extrinsic(
+			_equivocation_proof: sp_consensus_beefy::DoubleVotingProof<
+				BlockNumber,
+				BeefyId,
+				BeefySignature,
+			>,
+			_key_owner_proof: sp_consensus_beefy::OpaqueKeyOwnershipProof,
+		) -> Option<()> {
+			None
+		}
+
+		fn submit_report_fork_voting_unsigned_extrinsic(
+			_equivocation_proof:
+				sp_consensus_beefy::ForkVotingProof<
+					<Block as BlockT>::Header,
+					BeefyId,
+					sp_runtime::OpaqueValue
+				>,
+			_key_owner_proof: sp_consensus_beefy::OpaqueKeyOwnershipProof,
+		) -> Option<()> {
+			None
+		}
+
+		fn submit_report_future_block_voting_unsigned_extrinsic(
+			_equivocation_proof: sp_consensus_beefy::FutureBlockVotingProof<BlockNumber, BeefyId>,
+			_key_owner_proof: sp_consensus_beefy::OpaqueKeyOwnershipProof,
+		) -> Option<()> {
+			None
+		}
+
+		fn generate_key_ownership_proof(
+			_set_id: sp_consensus_beefy::ValidatorSetId,
+			_authority_id: BeefyId,
+		) -> Option<sp_consensus_beefy::OpaqueKeyOwnershipProof> {
+			None
+		}
+
+		fn generate_ancestry_proof(
+			_prev_block_number: BlockNumber,
+			_best_known_block_number: Option<BlockNumber>,
+		) -> Option<sp_runtime::OpaqueValue> {
+			None
+		}
+	}
+
+	impl mmr::MmrApi<Block, Hash, BlockNumber> for Runtime {
+		fn mmr_root() -> Result<Hash, mmr::Error> {
+			Err(mmr::Error::PalletNotIncluded)
+		}
+
+		fn mmr_leaf_count() -> Result<mmr::LeafIndex, mmr::Error> {
+			Err(mmr::Error::PalletNotIncluded)
+		}
+
+		fn generate_proof(
+			_block_numbers: Vec<BlockNumber>,
+			_best_known_block_number: Option<BlockNumber>,
+		) -> Result<(Vec<mmr::EncodableOpaqueLeaf>, mmr::LeafProof<Hash>), mmr::Error> {
+			Err(mmr::Error::PalletNotIncluded)
+		}
+
+		fn verify_proof(_leaves: Vec<mmr::EncodableOpaqueLeaf>, _proof: mmr::LeafProof<Hash>)
+			-> Result<(), mmr::Error>
+		{
+			Err(mmr::Error::PalletNotIncluded)
+		}
+
+		fn verify_proof_stateless(
+			_root: Hash,
+			_leaves: Vec<mmr::EncodableOpaqueLeaf>,
+			_proof: mmr::LeafProof<Hash>
+		) -> Result<(), mmr::Error> {
+			Err(mmr::Error::PalletNotIncluded)
 		}
 	}
 }

--- a/parachain-runtime/src/lib.rs
+++ b/parachain-runtime/src/lib.rs
@@ -47,8 +47,6 @@ use frame_system::{
 use pallet_xcm::{EnsureXcm, IsVoiceOfBody};
 use parachains_common::message_queue::{NarrowOriginToSibling, ParaIdToSibling};
 pub use sp_consensus_aura::sr25519::AuthorityId as AuraId;
-use sp_consensus_beefy::ecdsa_crypto::{AuthorityId as BeefyId, Signature as BeefySignature};
-use sp_mmr_primitives as mmr;
 pub use sp_runtime::{MultiAddress, Perbill, Permill};
 #[cfg(feature = "std")]
 use sp_version::NativeVersion;
@@ -899,93 +897,6 @@ impl_runtime_apis! {
 
 		fn preset_names() -> Vec<sp_genesis_builder::PresetId> {
 			Default::default()
-		}
-	}
-
-	impl sp_consensus_beefy::BeefyApi<Block, BeefyId> for Runtime {
-		fn beefy_genesis() -> Option<BlockNumber> {
-			// dummy implementation due to lack of BEEFY pallet.
-			None
-		}
-
-		fn validator_set() -> Option<sp_consensus_beefy::ValidatorSet<BeefyId>> {
-			// dummy implementation due to lack of BEEFY pallet.
-			None
-		}
-
-		fn submit_report_double_voting_unsigned_extrinsic(
-			_equivocation_proof: sp_consensus_beefy::DoubleVotingProof<
-				BlockNumber,
-				BeefyId,
-				BeefySignature,
-			>,
-			_key_owner_proof: sp_consensus_beefy::OpaqueKeyOwnershipProof,
-		) -> Option<()> {
-			None
-		}
-
-		fn submit_report_fork_voting_unsigned_extrinsic(
-			_equivocation_proof:
-				sp_consensus_beefy::ForkVotingProof<
-					<Block as BlockT>::Header,
-					BeefyId,
-					sp_runtime::OpaqueValue
-				>,
-			_key_owner_proof: sp_consensus_beefy::OpaqueKeyOwnershipProof,
-		) -> Option<()> {
-			None
-		}
-
-		fn submit_report_future_block_voting_unsigned_extrinsic(
-			_equivocation_proof: sp_consensus_beefy::FutureBlockVotingProof<BlockNumber, BeefyId>,
-			_key_owner_proof: sp_consensus_beefy::OpaqueKeyOwnershipProof,
-		) -> Option<()> {
-			None
-		}
-
-		fn generate_key_ownership_proof(
-			_set_id: sp_consensus_beefy::ValidatorSetId,
-			_authority_id: BeefyId,
-		) -> Option<sp_consensus_beefy::OpaqueKeyOwnershipProof> {
-			None
-		}
-
-		fn generate_ancestry_proof(
-			_prev_block_number: BlockNumber,
-			_best_known_block_number: Option<BlockNumber>,
-		) -> Option<sp_runtime::OpaqueValue> {
-			None
-		}
-	}
-
-	impl mmr::MmrApi<Block, Hash, BlockNumber> for Runtime {
-		fn mmr_root() -> Result<Hash, mmr::Error> {
-			Err(mmr::Error::PalletNotIncluded)
-		}
-
-		fn mmr_leaf_count() -> Result<mmr::LeafIndex, mmr::Error> {
-			Err(mmr::Error::PalletNotIncluded)
-		}
-
-		fn generate_proof(
-			_block_numbers: Vec<BlockNumber>,
-			_best_known_block_number: Option<BlockNumber>,
-		) -> Result<(Vec<mmr::EncodableOpaqueLeaf>, mmr::LeafProof<Hash>), mmr::Error> {
-			Err(mmr::Error::PalletNotIncluded)
-		}
-
-		fn verify_proof(_leaves: Vec<mmr::EncodableOpaqueLeaf>, _proof: mmr::LeafProof<Hash>)
-			-> Result<(), mmr::Error>
-		{
-			Err(mmr::Error::PalletNotIncluded)
-		}
-
-		fn verify_proof_stateless(
-			_root: Hash,
-			_leaves: Vec<mmr::EncodableOpaqueLeaf>,
-			_proof: mmr::LeafProof<Hash>
-		) -> Result<(), mmr::Error> {
-			Err(mmr::Error::PalletNotIncluded)
 		}
 	}
 }

--- a/parachain-runtime/src/xcm_config.rs
+++ b/parachain-runtime/src/xcm_config.rs
@@ -146,6 +146,7 @@ impl xcm_executor::Config for XcmConfig {
 	type HrmpNewChannelOpenRequestHandler = ();
 	type HrmpChannelAcceptedHandler = ();
 	type HrmpChannelClosingHandler = ();
+	type XcmRecorder = PolkadotXcm;
 }
 
 /// No local origins on this chain are allowed to dispatch XCM sends/executions.
@@ -188,8 +189,6 @@ impl pallet_xcm::Config for Runtime {
 	type SovereignAccountOf = LocationToAccountId;
 	type MaxLockers = ConstU32<8>;
 	type WeightInfo = pallet_xcm::TestWeightInfo;
-	#[cfg(feature = "runtime-benchmarks")]
-	type ReachableDest = ReachableDest;
 	type AdminOrigin = EnsureRoot<AccountId>;
 	type MaxRemoteLockConsumers = ConstU32<0>;
 	type RemoteLockConsumerIdentifier = ();

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -33,10 +33,12 @@ pallet-transaction-payment-rpc-runtime-api = { workspace = true }
 sp-api = { workspace = true }
 sp-block-builder = { workspace = true }
 sp-consensus-aura = { workspace = true }
+sp-consensus-beefy = { workspace = true }
 sp-consensus-grandpa = { workspace = true }
 sp-core = { workspace = true }
 sp-genesis-builder = { workspace = true }
 sp-inherents = { workspace = true }
+sp-mmr-primitives = { workspace = true }
 sp-offchain = { workspace = true }
 sp-runtime = { workspace = true }
 sp-session = { workspace = true }
@@ -87,10 +89,12 @@ std = [
 	"sp-api/std",
 	"sp-block-builder/std",
 	"sp-consensus-aura/std",
+	"sp-consensus-beefy/std",
 	"sp-consensus-grandpa/std",
 	"sp-core/std",
 	"sp-genesis-builder/std",
 	"sp-inherents/std",
+	"sp-mmr-primitives/std",
 	"sp-offchain/std",
 	"sp-runtime/std",
 	"sp-session/std",

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -13,8 +13,10 @@ build = "build.rs"
 targets = ["x86_64-unknown-linux-gnu"]
 
 [dependencies]
-codec = { package = "parity-scale-codec", version = "3.6.9", default-features = false, features = ["derive"] }
-scale-info = { version = "2.10.0", default-features = false, features = ["derive"] }
+codec = { features = [
+	"derive",
+], workspace = true }
+scale-info = { workspace = true }
 
 frame-executive = { workspace = true }
 frame-support = { workspace = true }
@@ -38,7 +40,6 @@ sp-inherents = { workspace = true }
 sp-offchain = { workspace = true }
 sp-runtime = { workspace = true }
 sp-session = { workspace = true }
-sp-std = { workspace = true }
 sp-storage = { workspace = true }
 sp-transaction-pool = { workspace = true }
 sp-version = { workspace = true }
@@ -93,7 +94,6 @@ std = [
 	"sp-offchain/std",
 	"sp-runtime/std",
 	"sp-session/std",
-	"sp-std/std",
 	"sp-storage/std",
 	"sp-transaction-pool/std",
 	"sp-version/std",

--- a/runtime/Cargo.toml
+++ b/runtime/Cargo.toml
@@ -33,12 +33,10 @@ pallet-transaction-payment-rpc-runtime-api = { workspace = true }
 sp-api = { workspace = true }
 sp-block-builder = { workspace = true }
 sp-consensus-aura = { workspace = true }
-sp-consensus-beefy = { workspace = true }
 sp-consensus-grandpa = { workspace = true }
 sp-core = { workspace = true }
 sp-genesis-builder = { workspace = true }
 sp-inherents = { workspace = true }
-sp-mmr-primitives = { workspace = true }
 sp-offchain = { workspace = true }
 sp-runtime = { workspace = true }
 sp-session = { workspace = true }
@@ -89,12 +87,10 @@ std = [
 	"sp-api/std",
 	"sp-block-builder/std",
 	"sp-consensus-aura/std",
-	"sp-consensus-beefy/std",
 	"sp-consensus-grandpa/std",
 	"sp-core/std",
 	"sp-genesis-builder/std",
 	"sp-inherents/std",
-	"sp-mmr-primitives/std",
 	"sp-offchain/std",
 	"sp-runtime/std",
 	"sp-session/std",

--- a/runtime/src/assets_config.rs
+++ b/runtime/src/assets_config.rs
@@ -36,4 +36,6 @@ impl pallet_assets::Config for Runtime {
 	type WeightInfo = pallet_assets::weights::SubstrateWeight<Runtime>;
 	type RemoveItemsLimit = ConstU32<1000>;
 	type CallbackHandle = ();
+	#[cfg(feature = "runtime-benchmarks")]
+	type BenchmarkHelper = ();
 }

--- a/runtime/src/contracts_config.rs
+++ b/runtime/src/contracts_config.rs
@@ -76,6 +76,7 @@ impl pallet_contracts::Config for Runtime {
 	type MaxCodeLen = ConstU32<{ 256 * 1024 }>;
 	type DefaultDepositLimit = DefaultDepositLimit;
 	type MaxStorageKeyLen = ConstU32<128>;
+	type MaxTransientStorageSize = ConstU32<{ 1024 * 1024 }>;
 	type MaxDebugBufferLen = ConstU32<{ 2 * 1024 * 1024 }>;
 	type UnsafeUnstableInterface = ConstBool<true>;
 	type CodeHashLockupDepositPercent = CodeHashLockupDepositPercent;

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -19,7 +19,9 @@ use frame_support::{
 use frame_system::limits::{BlockLength, BlockWeights};
 use polkadot_runtime_common::SlowAdjustingFeeUpdate;
 use sp_api::impl_runtime_apis;
+use sp_consensus_beefy::ecdsa_crypto::{AuthorityId as BeefyId, Signature as BeefySignature};
 use sp_core::{crypto::KeyTypeId, OpaqueMetadata};
+use sp_mmr_primitives as mmr;
 use sp_runtime::{
 	create_runtime_str, generic, impl_opaque_keys,
 	traits::{BlakeTwo256, Block as BlockT, IdentifyAccount, Verify},
@@ -545,6 +547,93 @@ impl_runtime_apis! {
 
 		fn preset_names() -> Vec<sp_genesis_builder::PresetId> {
 			Default::default()
+		}
+	}
+
+	impl sp_consensus_beefy::BeefyApi<Block, BeefyId> for Runtime {
+		fn beefy_genesis() -> Option<BlockNumber> {
+			// dummy implementation due to lack of BEEFY pallet.
+			None
+		}
+
+		fn validator_set() -> Option<sp_consensus_beefy::ValidatorSet<BeefyId>> {
+			// dummy implementation due to lack of BEEFY pallet.
+			None
+		}
+
+		fn submit_report_double_voting_unsigned_extrinsic(
+			_equivocation_proof: sp_consensus_beefy::DoubleVotingProof<
+				BlockNumber,
+				BeefyId,
+				BeefySignature,
+			>,
+			_key_owner_proof: sp_consensus_beefy::OpaqueKeyOwnershipProof,
+		) -> Option<()> {
+			None
+		}
+
+		fn submit_report_fork_voting_unsigned_extrinsic(
+			_equivocation_proof:
+				sp_consensus_beefy::ForkVotingProof<
+					<Block as BlockT>::Header,
+					BeefyId,
+					sp_runtime::OpaqueValue
+				>,
+			_key_owner_proof: sp_consensus_beefy::OpaqueKeyOwnershipProof,
+		) -> Option<()> {
+			None
+		}
+
+		fn submit_report_future_block_voting_unsigned_extrinsic(
+			_equivocation_proof: sp_consensus_beefy::FutureBlockVotingProof<BlockNumber, BeefyId>,
+			_key_owner_proof: sp_consensus_beefy::OpaqueKeyOwnershipProof,
+		) -> Option<()> {
+			None
+		}
+
+		fn generate_key_ownership_proof(
+			_set_id: sp_consensus_beefy::ValidatorSetId,
+			_authority_id: BeefyId,
+		) -> Option<sp_consensus_beefy::OpaqueKeyOwnershipProof> {
+			None
+		}
+
+		fn generate_ancestry_proof(
+			_prev_block_number: BlockNumber,
+			_best_known_block_number: Option<BlockNumber>,
+		) -> Option<sp_runtime::OpaqueValue> {
+			None
+		}
+	}
+
+	impl mmr::MmrApi<Block, Hash, BlockNumber> for Runtime {
+		fn mmr_root() -> Result<Hash, mmr::Error> {
+			Err(mmr::Error::PalletNotIncluded)
+		}
+
+		fn mmr_leaf_count() -> Result<mmr::LeafIndex, mmr::Error> {
+			Err(mmr::Error::PalletNotIncluded)
+		}
+
+		fn generate_proof(
+			_block_numbers: Vec<BlockNumber>,
+			_best_known_block_number: Option<BlockNumber>,
+		) -> Result<(Vec<mmr::EncodableOpaqueLeaf>, mmr::LeafProof<Hash>), mmr::Error> {
+			Err(mmr::Error::PalletNotIncluded)
+		}
+
+		fn verify_proof(_leaves: Vec<mmr::EncodableOpaqueLeaf>, _proof: mmr::LeafProof<Hash>)
+			-> Result<(), mmr::Error>
+		{
+			Err(mmr::Error::PalletNotIncluded)
+		}
+
+		fn verify_proof_stateless(
+			_root: Hash,
+			_leaves: Vec<mmr::EncodableOpaqueLeaf>,
+			_proof: mmr::LeafProof<Hash>
+		) -> Result<(), mmr::Error> {
+			Err(mmr::Error::PalletNotIncluded)
 		}
 	}
 }

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -19,9 +19,7 @@ use frame_support::{
 use frame_system::limits::{BlockLength, BlockWeights};
 use polkadot_runtime_common::SlowAdjustingFeeUpdate;
 use sp_api::impl_runtime_apis;
-use sp_consensus_beefy::ecdsa_crypto::{AuthorityId as BeefyId, Signature as BeefySignature};
 use sp_core::{crypto::KeyTypeId, OpaqueMetadata};
-use sp_mmr_primitives as mmr;
 use sp_runtime::{
 	create_runtime_str, generic, impl_opaque_keys,
 	traits::{BlakeTwo256, Block as BlockT, IdentifyAccount, Verify},
@@ -547,93 +545,6 @@ impl_runtime_apis! {
 
 		fn preset_names() -> Vec<sp_genesis_builder::PresetId> {
 			Default::default()
-		}
-	}
-
-	impl sp_consensus_beefy::BeefyApi<Block, BeefyId> for Runtime {
-		fn beefy_genesis() -> Option<BlockNumber> {
-			// dummy implementation due to lack of BEEFY pallet.
-			None
-		}
-
-		fn validator_set() -> Option<sp_consensus_beefy::ValidatorSet<BeefyId>> {
-			// dummy implementation due to lack of BEEFY pallet.
-			None
-		}
-
-		fn submit_report_double_voting_unsigned_extrinsic(
-			_equivocation_proof: sp_consensus_beefy::DoubleVotingProof<
-				BlockNumber,
-				BeefyId,
-				BeefySignature,
-			>,
-			_key_owner_proof: sp_consensus_beefy::OpaqueKeyOwnershipProof,
-		) -> Option<()> {
-			None
-		}
-
-		fn submit_report_fork_voting_unsigned_extrinsic(
-			_equivocation_proof:
-				sp_consensus_beefy::ForkVotingProof<
-					<Block as BlockT>::Header,
-					BeefyId,
-					sp_runtime::OpaqueValue
-				>,
-			_key_owner_proof: sp_consensus_beefy::OpaqueKeyOwnershipProof,
-		) -> Option<()> {
-			None
-		}
-
-		fn submit_report_future_block_voting_unsigned_extrinsic(
-			_equivocation_proof: sp_consensus_beefy::FutureBlockVotingProof<BlockNumber, BeefyId>,
-			_key_owner_proof: sp_consensus_beefy::OpaqueKeyOwnershipProof,
-		) -> Option<()> {
-			None
-		}
-
-		fn generate_key_ownership_proof(
-			_set_id: sp_consensus_beefy::ValidatorSetId,
-			_authority_id: BeefyId,
-		) -> Option<sp_consensus_beefy::OpaqueKeyOwnershipProof> {
-			None
-		}
-
-		fn generate_ancestry_proof(
-			_prev_block_number: BlockNumber,
-			_best_known_block_number: Option<BlockNumber>,
-		) -> Option<sp_runtime::OpaqueValue> {
-			None
-		}
-	}
-
-	impl mmr::MmrApi<Block, Hash, BlockNumber> for Runtime {
-		fn mmr_root() -> Result<Hash, mmr::Error> {
-			Err(mmr::Error::PalletNotIncluded)
-		}
-
-		fn mmr_leaf_count() -> Result<mmr::LeafIndex, mmr::Error> {
-			Err(mmr::Error::PalletNotIncluded)
-		}
-
-		fn generate_proof(
-			_block_numbers: Vec<BlockNumber>,
-			_best_known_block_number: Option<BlockNumber>,
-		) -> Result<(Vec<mmr::EncodableOpaqueLeaf>, mmr::LeafProof<Hash>), mmr::Error> {
-			Err(mmr::Error::PalletNotIncluded)
-		}
-
-		fn verify_proof(_leaves: Vec<mmr::EncodableOpaqueLeaf>, _proof: mmr::LeafProof<Hash>)
-			-> Result<(), mmr::Error>
-		{
-			Err(mmr::Error::PalletNotIncluded)
-		}
-
-		fn verify_proof_stateless(
-			_root: Hash,
-			_leaves: Vec<mmr::EncodableOpaqueLeaf>,
-			_proof: mmr::LeafProof<Hash>
-		) -> Result<(), mmr::Error> {
-			Err(mmr::Error::PalletNotIncluded)
 		}
 	}
 }


### PR DESCRIPTION
This PR uplifts versions and sync `substrate-contracts-node` with SDK version `polkadot-stable2409`.
Aside from the application of the different commits coming with the version update, the collator has been change from using a  `basic` collator to `lookahead`.
Crate versions have also been bumped to `0.42.0`.